### PR TITLE
Rolled back to sbt 0.13.16 because publishing fails in sbt 1.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=0.13.16

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform"      % "1.8.0")
-addSbtPlugin("com.jsuereth"    % "sbt-pgp"              % "1.1.0")
+addSbtPlugin("com.jsuereth"    % "sbt-pgp"              % "1.0.0")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 // scripted for plugin testing
-libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }
+libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value }

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,3 +1,4 @@
+ScriptedPlugin.scriptedSettings 
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
   Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 }


### PR DESCRIPTION
I want to publish sbt-scalatra 1.0.1, but publishing fails in sbt 1.0. So I propose once rolled back to sbt 0.13.16 until this problem will be resolved.