### PR TITLE
Updates xsbt-web-plugin to 4.0.2 to get jetty 9.4.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file(".")).settings(
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   libraryDependencies += {
     Defaults.sbtPluginExtra(
-      "com.earldouglas" % "xsbt-web-plugin" % "4.0.1",
+      "com.earldouglas" % "xsbt-web-plugin" % "4.0.2",
       (sbtBinaryVersion in pluginCrossBuild).value,
       (scalaBinaryVersion in pluginCrossBuild).value
     )


### PR DESCRIPTION
Fixes #55

which was caused by https://github.com/eclipse/jetty.project/issues/1692

https://github.com/earldouglas/xsbt-web-plugin/issues/361 updated xsbt-web-plugin with the fix.