### PR TITLE
Delted unnecessary task key

### DIFF
--- a/src/main/scala/org/scalatra/sbt/PluginKeys.scala
+++ b/src/main/scala/org/scalatra/sbt/PluginKeys.scala
@@ -4,6 +4,5 @@ import sbt._
 import Keys._
 
 object PluginKeys {
-  val generateJRebel = taskKey[Unit]("Generates a rebel.xml for a webapp")
   val browse = taskKey[Unit]("Open a web browser to localhost on container:port")
 }


### PR DESCRIPTION
JRebel plugin was removed in version 1.0.3, so the task key is
no longer needed to be There was, but it hadn't been removed.