### PR TITLE
 deleted sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: scala
-sudo: false
 jdk:
   - openjdk8
 


### PR DESCRIPTION
Since travis has moved from a container-based environment to a VM-based
environment, there is no need to specify `sudo: false` anymore.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration