### PR TITLE
fix warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies += {
     Defaults.sbtPluginExtra(
       "com.earldouglas" % "xsbt-web-plugin" % "4.2.5",
-      (sbtBinaryVersion in pluginCrossBuild).value,
-      (scalaBinaryVersion in pluginCrossBuild).value
+      (pluginCrossBuild / sbtBinaryVersion).value,
+      (pluginCrossBuild / scalaBinaryVersion).value
     )
   },
   publishTo := {


### PR DESCRIPTION
```
/home/runner/work/sbt-scalatra/sbt-scalatra/build.sbt:13: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
      (scalaBinaryVersion in pluginCrossBuild).value
                          ^
/home/runner/work/sbt-scalatra/sbt-scalatra/build.sbt:12: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-0[13](https://github.com/scalatra/sbt-scalatra/actions/runs/11239833076/job/31247807312#step:4:14)x.html#slash
      (sbtBinaryVersion in pluginCrossBuild).value,
                        ^
```